### PR TITLE
remove minimum from amperage and voltage

### DIFF
--- a/EVChargingStation/doc/spec.md
+++ b/EVChargingStation/doc/spec.md
@@ -83,7 +83,6 @@ EVChargingStation:
     amperage:    
       description: 'The total amperage offered by the charging station.'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    
@@ -394,7 +393,6 @@ EVChargingStation:
     voltage:    
       description: 'The total voltage offered by the charging station'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    

--- a/EVChargingStation/doc/spec_ES.md
+++ b/EVChargingStation/doc/spec_ES.md
@@ -83,7 +83,6 @@ EVChargingStation:
     amperage:    
       description: 'The total amperage offered by the charging station.'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    
@@ -394,7 +393,6 @@ EVChargingStation:
     voltage:    
       description: 'The total voltage offered by the charging station'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    

--- a/EVChargingStation/doc/spec_FR.md
+++ b/EVChargingStation/doc/spec_FR.md
@@ -83,7 +83,6 @@ EVChargingStation:
     amperage:    
       description: 'The total amperage offered by the charging station.'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    
@@ -394,7 +393,6 @@ EVChargingStation:
     voltage:    
       description: 'The total voltage offered by the charging station'    
       exclusiveMinimum: 0    
-      minimum: 0    
       type: Property    
       x-ngsi:    
         model: http://schema.org/Number    

--- a/EVChargingStation/model.yaml
+++ b/EVChargingStation/model.yaml
@@ -68,7 +68,6 @@ EVChargingStation:
     amperage:
       description: 'The total amperage offered by the charging station.'
       exclusiveMinimum: 0
-      minimum: 0
       type: Property
       x-ngsi:
         model: http://schema.org/Number
@@ -379,7 +378,6 @@ EVChargingStation:
     voltage:
       description: 'The total voltage offered by the charging station'
       exclusiveMinimum: 0
-      minimum: 0
       type: Property
       x-ngsi:
         model: http://schema.org/Number

--- a/EVChargingStation/schema.json
+++ b/EVChargingStation/schema.json
@@ -123,13 +123,11 @@
         },
         "amperage": {
           "type": "number",
-          "minimum": 0,
           "exclusiveMinimum": 0,
           "description": "Property. The total amperage offered by the charging station.. Model:'http://schema.org/Number'. Units:'Ampers (A)'"
         },
         "voltage": {
           "type": "number",
-          "minimum": 0,
           "exclusiveMinimum": 0,
           "description": "Property. The total voltage offered by the charging station. Model:'http://schema.org/Number'. Units:'Volts (V)'"
         },


### PR DESCRIPTION
A schema validation of an instance of EVChargingStation always fails.
If the value is `0` (or even not present) and `minimum` and `exclusiveMinimum` conditions are set to `0`, a jsonschema validator will check for minimum `0 >= 0` -> `True` and for exclusiveMinimum `0 > 0` -> `False`.  
As long as one condition evaluates to `False` the instance is not considered valid.

https://json-schema.org/understanding-json-schema/reference/numeric.html states that

>While you can specify both of minimum and exclusiveMinimum or both of maximum and exclusiveMaximum, it doesn’t really make sense to do so.

As a result, I removed the `minimum` condition from fields where `exclusiveMinimum` is already specified (`amperage` and `voltage` field)
