### PR TITLE
update roadSegment with 2 attributes

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -84,3 +84,12 @@ contributors:
  organization: IUDX
  project: 
  comments:
+ 
+ name: Gert
+ surname: Van de Wouwer
+ mail: Gert.VandeWouwer@gmail.com 
+ organization: Digipolis Antwerpen
+ project: 
+ comments: 
+ 
+ 

--- a/RoadSegment/ADOPTERS.yaml
+++ b/RoadSegment/ADOPTERS.yaml
@@ -1,10 +1,10 @@
 description: This is a compilation list of the current adopters of the data model RoadSegment of the Subject dataModel.Transportation.  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
 currentAdopters:
 -
- adopter: 
- description: 
- mail: 
- organization: 
+ adopter: Gert Van de Wouwer
+ description: Extra attributes status and statusDescription to allow modelling temporary road closures.
+ mail: Gert.VandeWouwer@gmail.com
+ organization: Digipolis Antwerpen
  project: 
- comments: 
- startDate: 
+ comments: Can be used to model the effect of bridge or lock openings on traffic that runs over them. 
+ startDate: '2022-01-15'

--- a/RoadSegment/examples/example-geojsonfeature.json
+++ b/RoadSegment/examples/example-geojsonfeature.json
@@ -1,136 +1,128 @@
 {
-	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
-	"type": "Feature",
-	"geometry": {
-		"type": "GeoProperty",
-		"value": {
-			"type": "LineString",
-			"coordinates": [
-				[
-					-4.7299180606009,
-					41.6844918725019
-				],
-				[
-					-4.72855890957602,
-					41.6860596957855
-				],
-				[
-					-4.5520357341647,
-					41.8569278186523
-				],
-				[
-					-4.55167335377909,
-					41.8570461783071
-				]
-			]
-		}
-	},
-	"properties": {
-		"type": "RoadSegment",
-		"category": {
-			"type": "Property",
-			"value": [
-				"oneway"
-			]
-		},
-		"endPoint": {
-			"type": "Property",
-			"value": {
-				"type": "Point",
-				"coordinates": [
-					-4.55167335377909,
-					41.8570461783071
-				]
-			}
-		},
-		"name": {
-			"type": "Property",
-			"value": "Valladolid-Dueñas"
-		},
-		"startPoint": {
-			"type": "Property",
-			"value": {
-				"type": "Point",
-				"coordinates": [
-					-4.7299180606009,
-					41.6844918725019
-				]
-			}
-		},
-		"allowedVehicleType": {
-			"type": "Property",
-			"value": [
-				"car",
-				"bus",
-				"lorry",
-				"trailer",
-				"tanker",
-				"van",
-				"caravan"
-			]
-		},
-		"source": {
-			"type": "Property",
-			"value": "http://wwww.openstreetmap.org"
-		},
-		"totalLaneNumber": {
-			"type": "Property",
-			"value": 2
-		},
-		"location": {
-			"type": "GeoProperty",
-			"value": {
-				"type": "LineString",
-				"coordinates": [
-					[
-						-4.7299180606009,
-						41.6844918725019
-					],
-					[
-						-4.72855890957602,
-						41.6860596957855
-					],
-					[
-						-4.5520357341647,
-						41.8569278186523
-					],
-					[
-						-4.55167335377909,
-						41.8570461783071
-					]
-				]
-			}
-		},
-		"minimumAllowedSpeed": {
-			"type": "Property",
-			"value": 60
-		},
-		"refRoad": {
-			"type": "Relationship",
-			"object": "urn:ngsi-ld:Road:Spain-Road-A62"
-		},
-		"maximumAllowedSpeed": {
-			"type": "Property",
-			"value": 120
-		},
-		"laneUsage": {
-			"type": "Property",
-			"value": [
-				"forward",
-				"forward"
-			]
-		},
-		"status": {
-			"type": "Property",
-			"value": "open"
-		},
-		"statusDescription": {
-			"type": "Property",
-			"value": "Bridge state = DOWN"
-		},
-		"@context": [
-			"https://smartdatamodels.org/context.jsonld",
-			"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
-		]
-	}
+  "id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
+  "type": "Feature",
+  "geometry": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          -4.7299180606009,
+          41.6844918725019
+        ],
+        [
+          -4.72855890957602,
+          41.6860596957855
+        ],
+        [
+          -4.5520357341647,
+          41.8569278186523
+        ],
+        [
+          -4.55167335377909,
+          41.8570461783071
+        ]
+      ]
+    }
+  },
+  "properties": {
+    "type": "RoadSegment",
+    "category": {
+      "type": "Property",
+      "value": [
+        "oneway"
+      ]
+    },
+    "endPoint": {
+      "type": "Property",
+      "value": {
+        "type": "Point",
+        "coordinates": [
+          -4.55167335377909,
+          41.8570461783071
+        ]
+      }
+    },
+    "name": {
+      "type": "Property",
+      "value": "Valladolid-Due\u00f1as"
+    },
+    "startPoint": {
+      "type": "Property",
+      "value": {
+        "type": "Point",
+        "coordinates": [
+          -4.7299180606009,
+          41.6844918725019
+        ]
+      }
+    },
+    "allowedVehicleType": {
+      "type": "Property",
+      "value": [
+        "car",
+        "bus",
+        "lorry",
+        "trailer",
+        "tanker",
+        "van",
+        "caravan"
+      ]
+    },
+    "source": {
+      "type": "Property",
+      "value": "http://wwww.openstreetmap.org"
+    },
+    "totalLaneNumber": {
+      "type": "Property",
+      "value": 2
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -4.7299180606009,
+            41.6844918725019
+          ],
+          [
+            -4.72855890957602,
+            41.6860596957855
+          ],
+          [
+            -4.5520357341647,
+            41.8569278186523
+          ],
+          [
+            -4.55167335377909,
+            41.8570461783071
+          ]
+        ]
+      }
+    },
+    "minimumAllowedSpeed": {
+      "type": "Property",
+      "value": 60
+    },
+    "refRoad": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Road:Spain-Road-A62"
+    },
+    "maximumAllowedSpeed": {
+      "type": "Property",
+      "value": 120
+    },
+    "laneUsage": {
+      "type": "Property",
+      "value": [
+        "forward",
+        "forward"
+      ]
+    },
+    "@context": [
+      "https://smartdatamodels.org/context.jsonld",
+      "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+    ]
+  }
 }

--- a/RoadSegment/examples/example-geojsonfeature.json
+++ b/RoadSegment/examples/example-geojsonfeature.json
@@ -1,128 +1,136 @@
 {
-  "id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
-  "type": "Feature",
-  "geometry": {
-    "type": "GeoProperty",
-    "value": {
-      "type": "LineString",
-      "coordinates": [
-        [
-          -4.7299180606009,
-          41.6844918725019
-        ],
-        [
-          -4.72855890957602,
-          41.6860596957855
-        ],
-        [
-          -4.5520357341647,
-          41.8569278186523
-        ],
-        [
-          -4.55167335377909,
-          41.8570461783071
-        ]
-      ]
-    }
-  },
-  "properties": {
-    "type": "RoadSegment",
-    "category": {
-      "type": "Property",
-      "value": [
-        "oneway"
-      ]
-    },
-    "endPoint": {
-      "type": "Property",
-      "value": {
-        "type": "Point",
-        "coordinates": [
-          -4.55167335377909,
-          41.8570461783071
-        ]
-      }
-    },
-    "name": {
-      "type": "Property",
-      "value": "Valladolid-Due\u00f1as"
-    },
-    "startPoint": {
-      "type": "Property",
-      "value": {
-        "type": "Point",
-        "coordinates": [
-          -4.7299180606009,
-          41.6844918725019
-        ]
-      }
-    },
-    "allowedVehicleType": {
-      "type": "Property",
-      "value": [
-        "car",
-        "bus",
-        "lorry",
-        "trailer",
-        "tanker",
-        "van",
-        "caravan"
-      ]
-    },
-    "source": {
-      "type": "Property",
-      "value": "http://wwww.openstreetmap.org"
-    },
-    "totalLaneNumber": {
-      "type": "Property",
-      "value": 2
-    },
-    "location": {
-      "type": "GeoProperty",
-      "value": {
-        "type": "LineString",
-        "coordinates": [
-          [
-            -4.7299180606009,
-            41.6844918725019
-          ],
-          [
-            -4.72855890957602,
-            41.6860596957855
-          ],
-          [
-            -4.5520357341647,
-            41.8569278186523
-          ],
-          [
-            -4.55167335377909,
-            41.8570461783071
-          ]
-        ]
-      }
-    },
-    "minimumAllowedSpeed": {
-      "type": "Property",
-      "value": 60
-    },
-    "refRoad": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Road:Spain-Road-A62"
-    },
-    "maximumAllowedSpeed": {
-      "type": "Property",
-      "value": 120
-    },
-    "laneUsage": {
-      "type": "Property",
-      "value": [
-        "forward",
-        "forward"
-      ]
-    },
-    "@context": [
-      "https://smartdatamodels.org/context.jsonld",
-      "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
-    ]
-  }
+	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
+	"type": "Feature",
+	"geometry": {
+		"type": "GeoProperty",
+		"value": {
+			"type": "LineString",
+			"coordinates": [
+				[
+					-4.7299180606009,
+					41.6844918725019
+				],
+				[
+					-4.72855890957602,
+					41.6860596957855
+				],
+				[
+					-4.5520357341647,
+					41.8569278186523
+				],
+				[
+					-4.55167335377909,
+					41.8570461783071
+				]
+			]
+		}
+	},
+	"properties": {
+		"type": "RoadSegment",
+		"category": {
+			"type": "Property",
+			"value": [
+				"oneway"
+			]
+		},
+		"endPoint": {
+			"type": "Property",
+			"value": {
+				"type": "Point",
+				"coordinates": [
+					-4.55167335377909,
+					41.8570461783071
+				]
+			}
+		},
+		"name": {
+			"type": "Property",
+			"value": "Valladolid-Dueñas"
+		},
+		"startPoint": {
+			"type": "Property",
+			"value": {
+				"type": "Point",
+				"coordinates": [
+					-4.7299180606009,
+					41.6844918725019
+				]
+			}
+		},
+		"allowedVehicleType": {
+			"type": "Property",
+			"value": [
+				"car",
+				"bus",
+				"lorry",
+				"trailer",
+				"tanker",
+				"van",
+				"caravan"
+			]
+		},
+		"source": {
+			"type": "Property",
+			"value": "http://wwww.openstreetmap.org"
+		},
+		"totalLaneNumber": {
+			"type": "Property",
+			"value": 2
+		},
+		"location": {
+			"type": "GeoProperty",
+			"value": {
+				"type": "LineString",
+				"coordinates": [
+					[
+						-4.7299180606009,
+						41.6844918725019
+					],
+					[
+						-4.72855890957602,
+						41.6860596957855
+					],
+					[
+						-4.5520357341647,
+						41.8569278186523
+					],
+					[
+						-4.55167335377909,
+						41.8570461783071
+					]
+				]
+			}
+		},
+		"minimumAllowedSpeed": {
+			"type": "Property",
+			"value": 60
+		},
+		"refRoad": {
+			"type": "Relationship",
+			"object": "urn:ngsi-ld:Road:Spain-Road-A62"
+		},
+		"maximumAllowedSpeed": {
+			"type": "Property",
+			"value": 120
+		},
+		"laneUsage": {
+			"type": "Property",
+			"value": [
+				"forward",
+				"forward"
+			]
+		},
+		"status": {
+			"type": "Property",
+			"value": "open"
+		},
+		"statusDescription": {
+			"type": "Property",
+			"value": "Bridge state = DOWN"
+		},
+		"@context": [
+			"https://smartdatamodels.org/context.jsonld",
+			"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+		]
+	}
 }

--- a/RoadSegment/examples/example-normalized.json
+++ b/RoadSegment/examples/example-normalized.json
@@ -1,56 +1,93 @@
 {
-  "id": "Spain-RoadSegment-A62-osm-24702186",
-  "type": "RoadSegment",
-  "category": {
-    "value": ["oneway"]
-  },
-  "endPoint": {
-    "value": {
-      "type": "Point",
-      "coordinates": [-4.55167335377909, 41.8570461783071]
-    }
-  },
-  "name": {
-    "value": "Valladolid-Due\u00f1as"
-  },
-  "startPoint": {
-    "value": {
-      "type": "Point",
-      "coordinates": [-4.7299180606009, 41.6844918725019]
-    }
-  },
-  "allowedVehicleType": {
-    "value": ["car", "bus", "lorry", "trailer", "tanker", "van", "caravan"]
-  },
-  "source": {
-    "value": "http://wwww.openstreetmap.org"
-  },
-  "totalLaneNumber": {
-    "value": 2
-  },
-  "location": {
-    "type": "geo:json",
-    "value": {
-      "type": "LineString",
-      "coordinates": [
-        [-4.7299180606009, 41.6844918725019],
-        [-4.72855890957602, 41.6860596957855],
-        [-4.5520357341647, 41.8569278186523],
-        [-4.55167335377909, 41.8570461783071]
-      ]
-    }
-  },
-  "minimumAllowedSpeed": {
-    "value": 60
-  },
-  "refRoad": {
-    "type": "Relationship",
-    "value": "Spain-Road-A62"
-  },
-  "maximumAllowedSpeed": {
-    "value": 120
-  },
-  "laneUsage": {
-    "value": ["forward", "forward"]
-  }
+	"id": "Spain-RoadSegment-A62-osm-24702186",
+	"type": "RoadSegment",
+	"category": {
+		"value": [
+			"oneway"
+		]
+	},
+	"endPoint": {
+		"value": {
+			"type": "Point",
+			"coordinates": [
+				-4.55167335377909,
+				41.8570461783071
+			]
+		}
+	},
+	"name": {
+		"value": "Valladolid-Dueñas"
+	},
+	"startPoint": {
+		"value": {
+			"type": "Point",
+			"coordinates": [
+				-4.7299180606009,
+				41.6844918725019
+			]
+		}
+	},
+	"allowedVehicleType": {
+		"value": [
+			"car",
+			"bus",
+			"lorry",
+			"trailer",
+			"tanker",
+			"van",
+			"caravan"
+		]
+	},
+	"source": {
+		"value": "http://wwww.openstreetmap.org"
+	},
+	"totalLaneNumber": {
+		"value": 2
+	},
+	"location": {
+		"type": "geo:json",
+		"value": {
+			"type": "LineString",
+			"coordinates": [
+				[
+					-4.7299180606009,
+					41.6844918725019
+				],
+				[
+					-4.72855890957602,
+					41.6860596957855
+				],
+				[
+					-4.5520357341647,
+					41.8569278186523
+				],
+				[
+					-4.55167335377909,
+					41.8570461783071
+				]
+			]
+		}
+	},
+	"minimumAllowedSpeed": {
+		"value": 60
+	},
+	"refRoad": {
+		"type": "Relationship",
+		"value": "Spain-Road-A62"
+	},
+	"maximumAllowedSpeed": {
+		"value": 120
+	},
+	"laneUsage": {
+		"value": [
+			"forward",
+			"forward"
+		]
+	},
+	"status": {
+		"value": "open"
+	},
+	"statusDescription": {
+		"value": "Bridge state = DOWN"
+	}
 }

--- a/RoadSegment/examples/example-normalized.jsonld
+++ b/RoadSegment/examples/example-normalized.jsonld
@@ -1,66 +1,109 @@
 {
 	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
 	"type": "RoadSegment",
-	"allowedVehicleType": [
-		"car",
-		"bus",
-		"lorry",
-		"trailer",
-		"tanker",
-		"van",
-		"caravan"
-	],
-	"category": [
-		"oneway"
-	],
-	"endPoint": {
-		"coordinates": [
-			-4.55167335377909,
-			41.8570461783071
-		],
-		"type": "Point"
+	"allowedVehicleType": {
+		"type": "Property",
+		"value": [
+			"car",
+			"bus",
+			"lorry",
+			"trailer",
+			"tanker",
+			"van",
+			"caravan"
+		]
 	},
-	"laneUsage": [
-		"forward",
-		"forward"
-	],
-	"location": {
-		"coordinates": [
-			[
-				-4.7299180606009,
-				41.6844918725019
-			],
-			[
-				-4.72855890957602,
-				41.6860596957855
-			],
-			[
-				-4.5520357341647,
-				41.8569278186523
-			],
-			[
+	"category": {
+		"type": "Property",
+		"value": [
+			"oneway"
+		]
+	},
+	"endPoint": {
+		"type": "Property",
+		"value": {
+			"type": "Point",
+			"coordinates": [
 				-4.55167335377909,
 				41.8570461783071
 			]
-		],
-		"type": "LineString"
+		}
 	},
-	"maximumAllowedSpeed": 120,
-	"minimumAllowedSpeed": 60,
-	"name": "Valladolid-Dueñas",
-	"refRoad": "urn:ngsi-ld:Road:Spain-Road-A62",
-	"source": "http://wwww.openstreetmap.org",
+	"laneUsage": {
+		"type": "Property",
+		"value": [
+			"forward",
+			"forward"
+		]
+	},
+	"location": {
+		"type": "GeoProperty",
+		"value": {
+			"type": "LineString",
+			"coordinates": [
+				[
+					-4.7299180606009,
+					41.6844918725019
+				],
+				[
+					-4.72855890957602,
+					41.6860596957855
+				],
+				[
+					-4.5520357341647,
+					41.8569278186523
+				],
+				[
+					-4.55167335377909,
+					41.8570461783071
+				]
+			]
+		}
+	},
+	"maximumAllowedSpeed": {
+		"type": "Property",
+		"value": 120
+	},
+	"minimumAllowedSpeed": {
+		"type": "Property",
+		"value": 60
+	},
+	"name": {
+		"type": "Property",
+		"value": "Valladolid-Dueñas"
+	},
+	"refRoad": {
+		"type": "Relationship",
+		"object": "urn:ngsi-ld:Road:Spain-Road-A62"
+	},
+	"source": {
+		"type": "Property",
+		"value": "http://wwww.openstreetmap.org"
+	},
 	"startPoint": {
-		"coordinates": [
-			-4.7299180606009,
-			41.6844918725019
-		],
-		"type": "Point"
+		"type": "Property",
+		"value": {
+			"type": "Point",
+			"coordinates": [
+				-4.7299180606009,
+				41.6844918725019
+			]
+		}
 	},
-	"totalLaneNumber": 2,
-	"status": "open",
-	"statusDescription": "Bridge state = DOWN",
+	"totalLaneNumber": {
+		"type": "Property",
+		"value": 2
+	},
+	"status": {
+		"type": "Property",
+		"value": "open"
+	},
+	"statusDescription": {
+		"type": "Property",
+		"value": "Bridge state = DOWN"
+	},
 	"@context": [
-		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+		"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
 	]
 }

--- a/RoadSegment/examples/example-normalized.jsonld
+++ b/RoadSegment/examples/example-normalized.jsonld
@@ -1,64 +1,66 @@
 {
-    "id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
-    "type": "RoadSegment",
-    "allowedVehicleType": [
-        "car",
-        "bus",
-        "lorry",
-        "trailer",
-        "tanker",
-        "van",
-        "caravan"
-    ],
-    "category": [
-        "oneway"
-    ],
-    "endPoint": {
-        "coordinates": [
-            -4.55167335377909,
-            41.8570461783071
-        ],
-        "type": "Point"
-    },
-    "laneUsage": [
-        "forward",
-        "forward"
-    ],
-    "location": {
-        "coordinates": [
-            [
-                -4.7299180606009,
-                41.6844918725019
-            ],
-            [
-                -4.72855890957602,
-                41.6860596957855
-            ],
-            [
-                -4.5520357341647,
-                41.8569278186523
-            ],
-            [
-                -4.55167335377909,
-                41.8570461783071
-            ]
-        ],
-        "type": "LineString"
-    },
-    "maximumAllowedSpeed": 120,
-    "minimumAllowedSpeed": 60,
-    "name": "Valladolid-Due\u00f1as",
-    "refRoad": "urn:ngsi-ld:Road:Spain-Road-A62",
-    "source": "http://wwww.openstreetmap.org",
-    "startPoint": {
-        "coordinates": [
-            -4.7299180606009,
-            41.6844918725019
-        ],
-        "type": "Point"
-    },
-    "totalLaneNumber": 2,
-    "@context": [
-        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
-    ]
+	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
+	"type": "RoadSegment",
+	"allowedVehicleType": [
+		"car",
+		"bus",
+		"lorry",
+		"trailer",
+		"tanker",
+		"van",
+		"caravan"
+	],
+	"category": [
+		"oneway"
+	],
+	"endPoint": {
+		"coordinates": [
+			-4.55167335377909,
+			41.8570461783071
+		],
+		"type": "Point"
+	},
+	"laneUsage": [
+		"forward",
+		"forward"
+	],
+	"location": {
+		"coordinates": [
+			[
+				-4.7299180606009,
+				41.6844918725019
+			],
+			[
+				-4.72855890957602,
+				41.6860596957855
+			],
+			[
+				-4.5520357341647,
+				41.8569278186523
+			],
+			[
+				-4.55167335377909,
+				41.8570461783071
+			]
+		],
+		"type": "LineString"
+	},
+	"maximumAllowedSpeed": 120,
+	"minimumAllowedSpeed": 60,
+	"name": "Valladolid-Dueñas",
+	"refRoad": "urn:ngsi-ld:Road:Spain-Road-A62",
+	"source": "http://wwww.openstreetmap.org",
+	"startPoint": {
+		"coordinates": [
+			-4.7299180606009,
+			41.6844918725019
+		],
+		"type": "Point"
+	},
+	"totalLaneNumber": 2,
+	"status": "open",
+	"statusDescription": "Bridge state = DOWN",
+	"@context": [
+		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+	]
 }

--- a/RoadSegment/examples/example.json
+++ b/RoadSegment/examples/example.json
@@ -1,38 +1,63 @@
 {
-  "id": "Spain-RoadSegment-A62-osm-24702186",
-  "type": "RoadSegment",
-  "name": "Valladolid-Dueñas",
-  "category": ["oneway"],
-  "refRoad": "Spain-Road-A62",
-  "totalLaneNumber": 2,
-  "maximumAllowedSpeed": 120,
-  "minimumAllowedSpeed": 60,
-  "startPoint": {
-    "type": "Point",
-    "coordinates": [-4.7299180606009, 41.6844918725019]
-  },
-  "endPoint": {
-    "type": "Point",
-    "coordinates": [-4.55167335377909, 41.8570461783071]
-  },
-  "allowedVehicleType": [
-    "car",
-    "bus",
-    "lorry",
-    "trailer",
-    "tanker",
-    "van",
-    "caravan"
-  ],
-  "location": {
-    "type": "LineString",
-    "coordinates": [
-      [-4.7299180606009, 41.6844918725019],
-      [-4.72855890957602, 41.6860596957855],
-      [-4.5520357341647, 41.8569278186523],
-      [-4.55167335377909, 41.8570461783071]
-    ]
-  },
-  "laneUsage": ["forward", "forward"],
-  "source": "http://wwww.openstreetmap.org"
+	"id": "Spain-RoadSegment-A62-osm-24702186",
+	"type": "RoadSegment",
+	"name": "Valladolid-Dueñas",
+	"category": [
+		"oneway"
+	],
+	"refRoad": "Spain-Road-A62",
+	"totalLaneNumber": 2,
+	"maximumAllowedSpeed": 120,
+	"minimumAllowedSpeed": 60,
+	"startPoint": {
+		"type": "Point",
+		"coordinates": [
+			-4.7299180606009,
+			41.6844918725019
+		]
+	},
+	"endPoint": {
+		"type": "Point",
+		"coordinates": [
+			-4.55167335377909,
+			41.8570461783071
+		]
+	},
+	"allowedVehicleType": [
+		"car",
+		"bus",
+		"lorry",
+		"trailer",
+		"tanker",
+		"van",
+		"caravan"
+	],
+	"location": {
+		"type": "LineString",
+		"coordinates": [
+			[
+				-4.7299180606009,
+				41.6844918725019
+			],
+			[
+				-4.72855890957602,
+				41.6860596957855
+			],
+			[
+				-4.5520357341647,
+				41.8569278186523
+			],
+			[
+				-4.55167335377909,
+				41.8570461783071
+			]
+		]
+	},
+	"laneUsage": [
+		"forward",
+		"forward"
+	],
+	"source": "http://wwww.openstreetmap.org",
+	"status": "open",
+	"statusDescription": "Bridge state = DOWN"
 }

--- a/RoadSegment/examples/example.jsonld
+++ b/RoadSegment/examples/example.jsonld
@@ -1,101 +1,109 @@
 {
-    "id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
-    "type": "RoadSegment",
-    "allowedVehicleType": {
-        "type": "Property",
-        "value": [
-            "car",
-            "bus",
-            "lorry",
-            "trailer",
-            "tanker",
-            "van",
-            "caravan"
-        ]
-    },
-    "category": {
-        "type": "Property",
-        "value": [
-            "oneway"
-        ]
-    },
-    "endPoint": {
-        "type": "Property",
-        "value": {
-            "type": "Point",
-            "coordinates": [
-                -4.55167335377909,
-                41.8570461783071
-            ]
-        }
-    },
-    "laneUsage": {
-        "type": "Property",
-        "value": [
-            "forward",
-            "forward"
-        ]
-    },
-    "location": {
-        "type": "GeoProperty",
-        "value": {
-            "type": "LineString",
-            "coordinates": [
-                [
-                    -4.7299180606009,
-                    41.6844918725019
-                ],
-                [
-                    -4.72855890957602,
-                    41.6860596957855
-                ],
-                [
-                    -4.5520357341647,
-                    41.8569278186523
-                ],
-                [
-                    -4.55167335377909,
-                    41.8570461783071
-                ]
-            ]
-        }
-    },
-    "maximumAllowedSpeed": {
-        "type": "Property",
-        "value": 120
-    },
-    "minimumAllowedSpeed": {
-        "type": "Property",
-        "value": 60
-    },
-    "name": {
-        "type": "Property",
-        "value": "Valladolid-Due\u00f1as"
-    },
-    "refRoad": {
-        "type": "Relationship",
-        "object": "urn:ngsi-ld:Road:Spain-Road-A62"
-    },
-    "source": {
-        "type": "Property",
-        "value": "http://wwww.openstreetmap.org"
-    },
-    "startPoint": {
-        "type": "Property",
-        "value": {
-            "type": "Point",
-            "coordinates": [
-                -4.7299180606009,
-                41.6844918725019
-            ]
-        }
-    },
-    "totalLaneNumber": {
-        "type": "Property",
-        "value": 2
-    },
-    "@context": [
-        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
-    ]
+	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
+	"type": "RoadSegment",
+	"allowedVehicleType": {
+		"type": "Property",
+		"value": [
+			"car",
+			"bus",
+			"lorry",
+			"trailer",
+			"tanker",
+			"van",
+			"caravan"
+		]
+	},
+	"category": {
+		"type": "Property",
+		"value": [
+			"oneway"
+		]
+	},
+	"endPoint": {
+		"type": "Property",
+		"value": {
+			"type": "Point",
+			"coordinates": [
+				-4.55167335377909,
+				41.8570461783071
+			]
+		}
+	},
+	"laneUsage": {
+		"type": "Property",
+		"value": [
+			"forward",
+			"forward"
+		]
+	},
+	"location": {
+		"type": "GeoProperty",
+		"value": {
+			"type": "LineString",
+			"coordinates": [
+				[
+					-4.7299180606009,
+					41.6844918725019
+				],
+				[
+					-4.72855890957602,
+					41.6860596957855
+				],
+				[
+					-4.5520357341647,
+					41.8569278186523
+				],
+				[
+					-4.55167335377909,
+					41.8570461783071
+				]
+			]
+		}
+	},
+	"maximumAllowedSpeed": {
+		"type": "Property",
+		"value": 120
+	},
+	"minimumAllowedSpeed": {
+		"type": "Property",
+		"value": 60
+	},
+	"name": {
+		"type": "Property",
+		"value": "Valladolid-Dueñas"
+	},
+	"refRoad": {
+		"type": "Relationship",
+		"object": "urn:ngsi-ld:Road:Spain-Road-A62"
+	},
+	"source": {
+		"type": "Property",
+		"value": "http://wwww.openstreetmap.org"
+	},
+	"startPoint": {
+		"type": "Property",
+		"value": {
+			"type": "Point",
+			"coordinates": [
+				-4.7299180606009,
+				41.6844918725019
+			]
+		}
+	},
+	"totalLaneNumber": {
+		"type": "Property",
+		"value": 2
+	},
+	"status": {
+		"type": "Property",
+		"value": "open"
+	},
+	"statusDescription": {
+		"type": "Property",
+		"value": "Bridge state = DOWN"
+	},
+	"@context": [
+		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+		"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
+	]
 }

--- a/RoadSegment/examples/example.jsonld
+++ b/RoadSegment/examples/example.jsonld
@@ -1,109 +1,66 @@
 {
 	"id": "urn:ngsi-ld:RoadSegment:Spain-RoadSegment-A62-osm-24702186",
 	"type": "RoadSegment",
-	"allowedVehicleType": {
-		"type": "Property",
-		"value": [
-			"car",
-			"bus",
-			"lorry",
-			"trailer",
-			"tanker",
-			"van",
-			"caravan"
-		]
-	},
-	"category": {
-		"type": "Property",
-		"value": [
-			"oneway"
-		]
-	},
+	"allowedVehicleType": [
+		"car",
+		"bus",
+		"lorry",
+		"trailer",
+		"tanker",
+		"van",
+		"caravan"
+	],
+	"category": [
+		"oneway"
+	],
 	"endPoint": {
-		"type": "Property",
-		"value": {
-			"type": "Point",
-			"coordinates": [
+		"coordinates": [
+			-4.55167335377909,
+			41.8570461783071
+		],
+		"type": "Point"
+	},
+	"laneUsage": [
+		"forward",
+		"forward"
+	],
+	"location": {
+		"coordinates": [
+			[
+				-4.7299180606009,
+				41.6844918725019
+			],
+			[
+				-4.72855890957602,
+				41.6860596957855
+			],
+			[
+				-4.5520357341647,
+				41.8569278186523
+			],
+			[
 				-4.55167335377909,
 				41.8570461783071
 			]
-		}
+		],
+		"type": "LineString"
 	},
-	"laneUsage": {
-		"type": "Property",
-		"value": [
-			"forward",
-			"forward"
-		]
-	},
-	"location": {
-		"type": "GeoProperty",
-		"value": {
-			"type": "LineString",
-			"coordinates": [
-				[
-					-4.7299180606009,
-					41.6844918725019
-				],
-				[
-					-4.72855890957602,
-					41.6860596957855
-				],
-				[
-					-4.5520357341647,
-					41.8569278186523
-				],
-				[
-					-4.55167335377909,
-					41.8570461783071
-				]
-			]
-		}
-	},
-	"maximumAllowedSpeed": {
-		"type": "Property",
-		"value": 120
-	},
-	"minimumAllowedSpeed": {
-		"type": "Property",
-		"value": 60
-	},
-	"name": {
-		"type": "Property",
-		"value": "Valladolid-Dueñas"
-	},
-	"refRoad": {
-		"type": "Relationship",
-		"object": "urn:ngsi-ld:Road:Spain-Road-A62"
-	},
-	"source": {
-		"type": "Property",
-		"value": "http://wwww.openstreetmap.org"
-	},
+	"maximumAllowedSpeed": 120,
+	"minimumAllowedSpeed": 60,
+	"name": "Valladolid-Dueñas",
+	"refRoad": "urn:ngsi-ld:Road:Spain-Road-A62",
+	"source": "http://wwww.openstreetmap.org",
 	"startPoint": {
-		"type": "Property",
-		"value": {
-			"type": "Point",
-			"coordinates": [
-				-4.7299180606009,
-				41.6844918725019
-			]
-		}
+		"coordinates": [
+			-4.7299180606009,
+			41.6844918725019
+		],
+		"type": "Point"
 	},
-	"totalLaneNumber": {
-		"type": "Property",
-		"value": 2
-	},
-	"status": {
-		"type": "Property",
-		"value": "open"
-	},
-	"statusDescription": {
-		"type": "Property",
-		"value": "Bridge state = DOWN"
-	},
+	"totalLaneNumber": 2,
+	"status": "open",
+	"statusDescription": "Bridge state = DOWN",
 	"@context": [
-		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-		"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
+		"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
 	]
 }

--- a/RoadSegment/schema.json
+++ b/RoadSegment/schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/schema#",
-	"$schemaVersion": "0.2.0",
+	"$schemaVersion": "0.3.0",
 	"modelTags": "",
 	"$id": "https://smart-data-models.github.io/dataModel.Transportation/RoadSegment/schema.json",
 	"title": "Smart Data Models - Transportation / Road Segment",

--- a/RoadSegment/schema.json
+++ b/RoadSegment/schema.json
@@ -141,7 +141,23 @@
               "link"
             ]
           }
-        }
+        },
+		"status": {
+			"type": "string",
+			"description": "Specific driving conditions on the roadsegment. Use statusDescription for additional information. Enum: ‘open, closed, limited’.  `open`: the roadsegment can be used in full intended capacity, `closed`: no traffic is possible, e.g. due to roadworks, an open bridge or lock, or any other event preventing traffic. `limited`: traffic is possible, but not in the full capacity.",
+			"items": {
+				"type": "string",
+				"enum": [
+					"open",
+					"closed",
+					"limited"
+				]
+			}
+		},
+		"statusDescription": {
+			"type": "string",
+			"description": "Additional information to the status attribute."
+		}			
       }
     }
   ],

--- a/RoadSegment/schema.json
+++ b/RoadSegment/schema.json
@@ -4,7 +4,7 @@
 	"modelTags": "",
 	"$id": "https://smart-data-models.github.io/dataModel.Transportation/RoadSegment/schema.json",
 	"title": "Smart Data Models - Transportation / Road Segment",
-	"description": "This entity contains a harmonised geographic and contextual description of a road segment. A collection of road segments are used to describe a Road.",
+	"description": "This entity contains a harmonised geographic and contextual description of a road segment. A collection of road segments are used to describe a Road. ",
 	"type": "object",
 	"allOf": [
 		{

--- a/RoadSegment/schema.json
+++ b/RoadSegment/schema.json
@@ -1,173 +1,173 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "$schemaVersion": "0.2.0",
-  "modelTags": "",
-  "$id": "https://smart-data-models.github.io/dataModel.Transportation/RoadSegment/schema.json",
-  "title": "Smart Data Models - Transportation / Road Segment",
-  "description": "This entity contains a harmonised geographic and contextual description of a road segment. A collection of road segments are used to describe a Road.",
-  "type": "object",
-  "allOf": [
-    {
-      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
-    },
-    {
-      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
-    },
-    {
-      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/PhysicalObject-Commons"
-    },
-    {
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "RoadSegment"
-          ],
-          "description": "Property. NGSI Entity type. It has to be RoadSegment"
-        },
-        "refRoad": {
-          "anyOf": [
-            {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256,
-              "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
-              "description": "Property. Identifier format of any NGSI entity"
-            },
-            {
-              "type": "string",
-              "format": "uri",
-              "description": "Property. Identifier format of any NGSI entity"
-            }
-          ],
-          "description": "Relationship. Road to which this road segment belongs to."
-        },
-        "startPoint": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons/properties/location"
-        },
-        "endPoint": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons/properties/location"
-        },
-        "startKilometer": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. The kilometer number (measured from the road's start point) where this road segment starts. Model:'https://schema.org/Number'. "
-        },
-        "endKilometer": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. The kilometer number (measured from the road's start point) where this road segment ends. Model:'https://schema.org/Number'. "
-        },
-        "allowedVehicleType": {
-          "type": "array",
-          "description": "Property. Vehicle type(s) allowed to transit through this road segment. Model:'https://schema.org/Text'. Enum:'agriculturalVehicle, bicycle, bus, car, caravan, carWithCaravan, carWithTrailer, constructionOrMaintenanceVehicle, lorry, moped, motorcycle, motorcycleWithSideCar, motorscooter, tanker, trailer, van, anyVehicle'. Allowed values: The following values defined by _VehicleTypeEnum_, [DATEX 2 version 2.3](http://d2docs.ndwcloud.nu/):",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculturalVehicle",
-              "bicycle",
-              "bus",
-              "car",
-              "caravan",
-              "carWithCaravan",
-              "carWithTrailer",
-              "constructionOrMaintenanceVehicle",
-              "lorry",
-              "moped",
-              "motorcycle",
-              "motorcycleWithSideCar",
-              "motorscooter",
-              "tanker",
-              "trailer",
-              "van",
-              "anyVehicle"
-            ]
-          }
-        },
-        "totalLaneNumber": {
-          "type": "number",
-          "minimum": 1,
-          "description": "Property. Total number of lanes offered by this road segment. Model:'https://schema.org/Number'."
-        },
-        "length": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. Total length of this road segment in kilometers. Model:'https://schema.org/length'. Units:'Kilometer (Km)'"
-        },
-        "maximumAllowedSpeed": {
-          "type": "number",
-          "description": "Property. Maximum allowed speed while transiting this road segment. More restrictive limits might be applied to specific vehicle types (trucks, caravans, etc.). Model:'https://schema.org/Number'. Units:'Kilometer per hour (Km/h)'",
-          "minimum": 0
-        },
-        "minimumAllowedSpeed": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. Minimum allowed speed while transiting this road segment. Model:'https://schema.org/Number'. Units:'Kilometer per hour (Km/h)'"
-        },
-        "maximumAllowedHeight": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. Maximum allowed height for vehicles transiting this road segment. Model:'https://schema.org/Number'. Units:'Meter (m)'. Model:'https://schema.org/height'"
-        },
-        "maximumAllowedWeight": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. Maximum allowed weight for vehicles transiting this road segment. Model:'https://schema.org/Number'. Units:'Kilogram (Kg)'. Model:'https://schema.org/weight'"
-        },
-        "width": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Property. Road's segment width.. Model:'https://schema.org/Number'. Units:'Meter (m)'"
-        },
-        "laneUsage": {
-          "type": "array",
-          "description": "Property. This attribute can be used to convey specific parameters describing each lane. Model:'https://schema.org/Text'. It must contain a string per road segment lane. The element 0 of the array must contain the information of lane 1, and so on. Format of the referred string must be: <lane_direction>, <lane_minimumAllowedSpeed>, <lane_maximumAllowedSpeed>, <lane_maximumAllowedHeight>, <lane_maximumAllowedWeight>. <lane_direction> is a text string with the following allowed values: `forward`. The lane is currently used in the `forwards` direction. `backward`. The lane is currently used in the `backwards` direction. The only mandatory parameter is `lane_direction`. If not specified, the rest of parameters can be assumed to be equal to those specified at entity level.",
-          "items": {
-            "type": "string",
-            "enum": [
-              "forward",
-              "backward"
-            ]
-          }
-        },
-        "category": {
-          "type": "array",
-          "description": "Property. Allows to convey extra characteristics of a road segment. Model:'https://schema.org/Text'. Enum:'oneway, toll, link'.  `oneway`: Flags whether the road segment can only be used in one direction. If not present it means road segment can be used in both directions (forwards and backwards). See also [http://wiki.openstreetmap.org/wiki/Key:oneway](http://wiki.openstreetmap.org/wiki/Key:oneway). `toll` : Flags whether the road segment is under toll fees. `link` : Flags whether this road segment is an auxiliary link segment for exiting or entering a road. See [https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link). Any other value meaningful to an application.",
-          "items": {
-            "type": "string",
-            "enum": [
-              "oneway",
-              "toll",
-              "link"
-            ]
-          }
-        },
-		"status": {
-			"type": "string",
-			"description": "Specific driving conditions on the roadsegment. Use statusDescription for additional information. Enum: ‘open, closed, limited’.  `open`: the roadsegment can be used in full intended capacity, `closed`: no traffic is possible, e.g. due to roadworks, an open bridge or lock, or any other event preventing traffic. `limited`: traffic is possible, but not in the full capacity.",
-			"items": {
-				"type": "string",
-				"enum": [
-					"open",
-					"closed",
-					"limited"
-				]
-			}
+	"$schema": "http://json-schema.org/schema#",
+	"$schemaVersion": "0.2.0",
+	"modelTags": "",
+	"$id": "https://smart-data-models.github.io/dataModel.Transportation/RoadSegment/schema.json",
+	"title": "Smart Data Models - Transportation / Road Segment",
+	"description": "This entity contains a harmonised geographic and contextual description of a road segment. A collection of road segments are used to describe a Road.",
+	"type": "object",
+	"allOf": [
+		{
+			"$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
 		},
-		"statusDescription": {
-			"type": "string",
-			"description": "Additional information to the status attribute."
-		}			
-      }
-    }
-  ],
-  "required": [
-    "id",
-    "name",
-    "type",
-    "refRoad",
-    "startPoint",
-    "endPoint",
-    "allowedVehicleType"
-  ]
+		{
+			"$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+		},
+		{
+			"$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/PhysicalObject-Commons"
+		},
+		{
+			"properties": {
+				"type": {
+					"type": "string",
+					"enum": [
+						"RoadSegment"
+					],
+					"description": "Property. NGSI Entity type. It has to be RoadSegment"
+				},
+				"refRoad": {
+					"anyOf": [
+						{
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 256,
+							"pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+							"description": "Property. Identifier format of any NGSI entity"
+						},
+						{
+							"type": "string",
+							"format": "uri",
+							"description": "Property. Identifier format of any NGSI entity"
+						}
+					],
+					"description": "Relationship. Road to which this road segment belongs to."
+				},
+				"startPoint": {
+					"$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons/properties/location"
+				},
+				"endPoint": {
+					"$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons/properties/location"
+				},
+				"startKilometer": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. The kilometer number (measured from the road's start point) where this road segment starts. Model:'https://schema.org/Number'. "
+				},
+				"endKilometer": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. The kilometer number (measured from the road's start point) where this road segment ends. Model:'https://schema.org/Number'. "
+				},
+				"allowedVehicleType": {
+					"type": "array",
+					"description": "Property. Vehicle type(s) allowed to transit through this road segment. Model:'https://schema.org/Text'. Enum:'agriculturalVehicle, bicycle, bus, car, caravan, carWithCaravan, carWithTrailer, constructionOrMaintenanceVehicle, lorry, moped, motorcycle, motorcycleWithSideCar, motorscooter, tanker, trailer, van, anyVehicle'. Allowed values: The following values defined by _VehicleTypeEnum_, [DATEX 2 version 2.3](http://d2docs.ndwcloud.nu/):",
+					"items": {
+						"type": "string",
+						"enum": [
+							"agriculturalVehicle",
+							"bicycle",
+							"bus",
+							"car",
+							"caravan",
+							"carWithCaravan",
+							"carWithTrailer",
+							"constructionOrMaintenanceVehicle",
+							"lorry",
+							"moped",
+							"motorcycle",
+							"motorcycleWithSideCar",
+							"motorscooter",
+							"tanker",
+							"trailer",
+							"van",
+							"anyVehicle"
+						]
+					}
+				},
+				"totalLaneNumber": {
+					"type": "number",
+					"minimum": 1,
+					"description": "Property. Total number of lanes offered by this road segment. Model:'https://schema.org/Number'."
+				},
+				"length": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. Total length of this road segment in kilometers. Model:'https://schema.org/length'. Units:'Kilometer (Km)'"
+				},
+				"maximumAllowedSpeed": {
+					"type": "number",
+					"description": "Property. Maximum allowed speed while transiting this road segment. More restrictive limits might be applied to specific vehicle types (trucks, caravans, etc.). Model:'https://schema.org/Number'. Units:'Kilometer per hour (Km/h)'",
+					"minimum": 0
+				},
+				"minimumAllowedSpeed": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. Minimum allowed speed while transiting this road segment. Model:'https://schema.org/Number'. Units:'Kilometer per hour (Km/h)'"
+				},
+				"maximumAllowedHeight": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. Maximum allowed height for vehicles transiting this road segment. Model:'https://schema.org/Number'. Units:'Meter (m)'. Model:'https://schema.org/height'"
+				},
+				"maximumAllowedWeight": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. Maximum allowed weight for vehicles transiting this road segment. Model:'https://schema.org/Number'. Units:'Kilogram (Kg)'. Model:'https://schema.org/weight'"
+				},
+				"width": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Property. Road's segment width.. Model:'https://schema.org/Number'. Units:'Meter (m)'"
+				},
+				"laneUsage": {
+					"type": "array",
+					"description": "Property. This attribute can be used to convey specific parameters describing each lane. Model:'https://schema.org/Text'. It must contain a string per road segment lane. The element 0 of the array must contain the information of lane 1, and so on. Format of the referred string must be: <lane_direction>, <lane_minimumAllowedSpeed>, <lane_maximumAllowedSpeed>, <lane_maximumAllowedHeight>, <lane_maximumAllowedWeight>. <lane_direction> is a text string with the following allowed values: `forward`. The lane is currently used in the `forwards` direction. `backward`. The lane is currently used in the `backwards` direction. The only mandatory parameter is `lane_direction`. If not specified, the rest of parameters can be assumed to be equal to those specified at entity level.",
+					"items": {
+						"type": "string",
+						"enum": [
+							"forward",
+							"backward"
+						]
+					}
+				},
+				"category": {
+					"type": "array",
+					"description": "Property. Allows to convey extra characteristics of a road segment. Model:'https://schema.org/Text'. Enum:'oneway, toll, link'.  `oneway`: Flags whether the road segment can only be used in one direction. If not present it means road segment can be used in both directions (forwards and backwards). See also [http://wiki.openstreetmap.org/wiki/Key:oneway](http://wiki.openstreetmap.org/wiki/Key:oneway). `toll` : Flags whether the road segment is under toll fees. `link` : Flags whether this road segment is an auxiliary link segment for exiting or entering a road. See [https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link). Any other value meaningful to an application.",
+					"items": {
+						"type": "string",
+						"enum": [
+							"oneway",
+							"toll",
+							"link"
+						]
+					}
+				},
+				"status": {
+					"type": "string",
+					"description": "Specific driving conditions on the roadsegment. Use statusDescription for additional information. Enum: ‘open, closed, limited’.  `open`: the roadsegment can be used in full intended capacity, `closed`: no traffic is possible, e.g. due to roadworks, an open bridge or lock, or any other event preventing traffic. `limited`: traffic is possible, but not in the full capacity.",
+					"items": {
+						"type": "string",
+						"enum": [
+							"open",
+							"closed",
+							"limited"
+						]
+					}
+				},
+				"statusDescription": {
+					"type": "string",
+					"description": "Additional information to the status attribute."
+				}
+			}
+		}
+	],
+	"required": [
+		"id",
+		"name",
+		"type",
+		"refRoad",
+		"startPoint",
+		"endPoint",
+		"allowedVehicleType"
+	]
 }

--- a/RoadSegment/schema.json
+++ b/RoadSegment/schema.json
@@ -144,7 +144,7 @@
 				},
 				"status": {
 					"type": "string",
-					"description": "Specific driving conditions on the roadsegment. Use statusDescription for additional information. Enum: ‘open, closed, limited’.  `open`: the roadsegment can be used in full intended capacity, `closed`: no traffic is possible, e.g. due to roadworks, an open bridge or lock, or any other event preventing traffic. `limited`: traffic is possible, but not in the full capacity.",
+					"description": "Property. Specific driving conditions on the roadsegment. Use statusDescription for additional information. Enum: ‘open, closed, limited’.  `open`: the roadsegment can be used in full intended capacity, `closed`: no traffic is possible, e.g. due to roadworks, an open bridge or lock, or any other event preventing traffic. `limited`: traffic is possible, but not in the full capacity.",
 					"items": {
 						"type": "string",
 						"enum": [
@@ -156,7 +156,7 @@
 				},
 				"statusDescription": {
 					"type": "string",
-					"description": "Additional information to the status attribute."
+					"description": "Property. Additional information to the status attribute."
 				}
 			}
 		}

--- a/Vehicle/ADOPTERS.yaml
+++ b/Vehicle/ADOPTERS.yaml
@@ -1,10 +1,10 @@
 description: This is a compilation list of the current adopters of the data model Vehicle of the Subject dataModel.Transportation.  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
 currentAdopters:
 -
- adopter: 
- description: 
- mail: 
- organization: 
+ adopter: Road closure information for the Antwerp fire brigade.
+ description: By inspecting the status and statusDescription attributes, one can determine if a particular roadSegment is available for regular traffic. Due to events like bridges or locks that open for ships, the road may be temporarely closed and traffic is forced to wait or take a detour. 
+ mail: gert.vandewouwer@digipolis.be
+ organization: Digipolis Antwerpen
  project: 
- comments: 
- startDate: 
+ comments: The added attributes may also be used for other events that temporarely limit of block traffic on a roadSegment.
+ startDate: 2022-01-15


### PR DESCRIPTION
I have added status and statusDescription to allow modelling a piece of road that runs over a bridge or lock. When the bridge is raised, no traffic is temporarily possible on the roadsegment. The attributes could also be used to model other types of events (such as roadworks) that temporarily limit or prohibit traffic.

The file passed the check_scheme validator in the learning zone.