### PR TITLE
Added battery property to FleetVehicleStatus

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -49,6 +49,13 @@ contributors:
     project:
     comments:
     year: 2022
+  - name: Víctor
+    surname: González
+    mail: vgonzalez@tlmat.unican.es
+    organization: Universidad de Cantabria (UC)
+    project: SEDIMARK. https://sedimark.eu/
+    comments:
+    year: 2023
   - name: Jone Begoña
     surname: Ibarzabal
     mail: jibarzabal@purpleblob.net

--- a/FleetVehicleStatus/ADOPTERS.yaml
+++ b/FleetVehicleStatus/ADOPTERS.yaml
@@ -1,10 +1,10 @@
 description: This is a compilation list of the current adopters of the data model FleetVehicleStatus of the Subject Transportation.
 currentAdopters:
 -
- adopter:
- description:
+ adopter: SEDIMARK project
+ description: Urban bike mobility planning use case in Santander
  mail: 
- organization:
- project: 
+ organization: 
+ project: https://sedimark.eu/
  comments: 
- startDate: 
+ startDate:

--- a/FleetVehicleStatus/examples/example-normalized.json
+++ b/FleetVehicleStatus/examples/example-normalized.json
@@ -1,6 +1,10 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
+  "battery": {
+    "type": "Number",
+    "value": 81.3
+  },
   "source": {
     "type": "URL",
     "value": "https://source.example.com"

--- a/FleetVehicleStatus/examples/example-normalized.json
+++ b/FleetVehicleStatus/examples/example-normalized.json
@@ -3,7 +3,7 @@
   "type": "FleetVehicleStatus",
   "battery": {
     "type": "Number",
-    "value": 81.3
+    "value": 0.81
   },
   "source": {
     "type": "URL",

--- a/FleetVehicleStatus/examples/example-normalized.jsonld
+++ b/FleetVehicleStatus/examples/example-normalized.jsonld
@@ -3,8 +3,7 @@
   "type": "FleetVehicleStatus",
   "battery": {
     "type": "Property",
-    "value": 81.3,
-    "unitCode": "P1",
+    "value": 0.81,
     "observedAt": "2016-08-22T10:18:16Z"
   },
   "bearing": {

--- a/FleetVehicleStatus/examples/example-normalized.jsonld
+++ b/FleetVehicleStatus/examples/example-normalized.jsonld
@@ -1,6 +1,12 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
+  "battery": {
+    "type": "Property",
+    "value": 81.3,
+    "unitCode": "P1",
+    "observedAt": "2016-08-22T10:18:16Z"
+  },
   "bearing": {
     "type": "Property",
     "value": 80,

--- a/FleetVehicleStatus/examples/example.json
+++ b/FleetVehicleStatus/examples/example.json
@@ -1,7 +1,7 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
-  "battery": 81.3,
+  "battery": 0.81,
   "source": "https://source.example.com",
   "dataProvider": "https://provider.example.com",
   "fleetVehicle": "urn:ngsi-ld:FleetVehicle:84c6a3a8-5aa6-11e8-bedc-27e105edd16f",

--- a/FleetVehicleStatus/examples/example.json
+++ b/FleetVehicleStatus/examples/example.json
@@ -1,6 +1,7 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
+  "battery": 81.3,
   "source": "https://source.example.com",
   "dataProvider": "https://provider.example.com",
   "fleetVehicle": "urn:ngsi-ld:FleetVehicle:84c6a3a8-5aa6-11e8-bedc-27e105edd16f",

--- a/FleetVehicleStatus/examples/example.jsonld
+++ b/FleetVehicleStatus/examples/example.jsonld
@@ -1,7 +1,7 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
-  "battery": 81.3,
+  "battery": 0.81,
   "bearing": 80,
   "currentOperative": {
     "givenName": "John Smith",

--- a/FleetVehicleStatus/examples/example.jsonld
+++ b/FleetVehicleStatus/examples/example.jsonld
@@ -1,6 +1,7 @@
 {
   "id": "urn:ngsi-ld:FleetVehicleStatus:16ea1c5c-5aa6-11e8-8144-4b82063ca31c",
   "type": "FleetVehicleStatus",
+  "battery": 81.3,
   "bearing": 80,
   "currentOperative": {
     "givenName": "John Smith",

--- a/FleetVehicleStatus/schema.json
+++ b/FleetVehicleStatus/schema.json
@@ -91,6 +91,12 @@
           "type": "number",
           "description": "Property. The current speed of the fleet vehicle (km/h). The timestamp element of the attribute should indicate when the reading was obtained. Units:'km/h'"
         },
+        "battery": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0,
+          "description": "Property. The current percentage of battery left in case of an electric vehicle, or a device connected to the vehicle."
+        },
         "bearing": {
           "type": "number",
           "description": "Property. The current bearing of the fleet vehicle in degrees relative to North. The timestamp element of the attribute should indicate when the reading was obtained."

--- a/FleetVehicleStatus/schema.json
+++ b/FleetVehicleStatus/schema.json
@@ -93,8 +93,8 @@
         },
         "battery": {
           "type": "number",
-          "minimum": 0.0,
-          "maximum": 100.0,
+          "minimum": 0,
+          "maximum": 1,
           "description": "Property. The current percentage of battery left in case of an electric vehicle, or a device connected to the vehicle."
         },
         "bearing": {


### PR DESCRIPTION
It allows battery level monitoring in vehicles where it is relevant (or devices attached to a vehicle).
To be used in the "Urban bike mobility planning" use case in Santander, within the SEDIMARK project.