### PR TITLE
added "leasingInfo" object (Vehicle)

### DIFF
--- a/Vehicle/ADOPTERS.yaml
+++ b/Vehicle/ADOPTERS.yaml
@@ -24,4 +24,11 @@ currentAdopters:
  project: https://sedimark.eu/
  comments: 
  startDate:
- 
+-
+ adopter: OS2 GPS-Connector
+ description: Open source project for danish municipalities to collect GPS data for analysis and optimisation
+ mail: os2fleetoptimiser@os2.eu
+ organization: https://www.os2.eu/
+ project: https://github.com/OS2sandbox/gps-connector
+ comments: Storing additional meta-data for vehicle, such as 'leasingInfo', is useful for the municipalities when managing their leased vehicles. Further, it is crucial for analysis and optimisation to bring in values such as 'monthlyLeaseCost' and 'allowedAnnualDistance' to account for the TCO of a vehicle.
+ startDate:

--- a/Vehicle/examples/example-normalized.json
+++ b/Vehicle/examples/example-normalized.json
@@ -166,5 +166,18 @@
       "zoneId": "2",
       "wardNum": 4
     }
+  },
+  "leasingInfo": {
+    "type": "StructuredValue",
+    "value": {
+      "leasingType": "Operating Lease",
+      "leasingStartDate": "2025-06-01T00:00:00.000Z",
+      "leasingEndDate": "2029-06-01T00:00:00.000Z",
+      "monthlyLeaseCost": 525,
+      "allowedAnnualDistance": 20000,
+      "allowedDistanceUnit": "kilometer",
+      "excessDistanceCost": 1,
+      "leasingProvider": "Municipality Leasing A/S"
+    }
   }
 }

--- a/Vehicle/examples/example-normalized.jsonld
+++ b/Vehicle/examples/example-normalized.jsonld
@@ -86,6 +86,19 @@
       "wardNum": 4
     }
   },
+  "leasingInfo": {
+    "type": "Property",
+    "value": {
+      "leasingType": "Operating Lease",
+      "leasingStartDate": "2025-06-01T00:00:00.000Z",
+      "leasingEndDate": "2029-06-01T00:00:00.000Z",
+      "monthlyLeaseCost": 525,
+      "allowedAnnualDistance": 20000,
+      "allowedDistanceUnit": "kilometer",
+      "excessDistanceCost": 1,
+      "leasingProvider": "Municipality Leasing A/S"
+    }
+  },
   "name": {
     "type": "Property",
     "value": "C Recogida 1"

--- a/Vehicle/examples/example.json
+++ b/Vehicle/examples/example.json
@@ -55,5 +55,15 @@
     "wardName": "Bangalore Urban",
     "zoneId": "2",
     "wardNum": 4
+  },
+  "leasingInfo": {
+    "leasingType": "Operating Lease",
+    "leasingStartDate": "2025-06-01T00:00:00.000Z",
+    "leasingEndDate": "2029-06-01T00:00:00.000Z",
+    "monthlyLeaseCost": 525,
+    "allowedAnnualDistance": 20000,
+    "allowedDistanceUnit": "kilometer",
+    "excessDistanceCost": 1,
+    "leasingProvider": "Municipality Leasing A/S"
   }
 }

--- a/Vehicle/examples/example.jsonld
+++ b/Vehicle/examples/example.jsonld
@@ -36,6 +36,16 @@
     "zoneId": "2",
     "wardNum": 4
   },
+  "leasingInfo": {
+    "leasingType": "Operating Lease",
+    "leasingStartDate": "2025-06-01T00:00:00.000Z",
+    "leasingEndDate": "2029-06-01T00:00:00.000Z",
+    "monthlyLeaseCost": 525,
+    "allowedAnnualDistance": 20000,
+    "allowedDistanceUnit": "kilometer",
+    "excessDistanceCost": 1,
+    "leasingProvider": "Municipality Leasing A/S"
+  },
   "name": "C Recogida 1",
   "observationDateTime": "2021-03-11T15:51:02+05:30",
   "refVehicleModel": "urn:ngsi-ld:VehicleModel:vehiclemodel:econic",

--- a/Vehicle/schema.json
+++ b/Vehicle/schema.json
@@ -416,6 +416,53 @@
               "description": "Property. Model:'https://schema.org/Number'. Ward number corresponding to this observation"
             }
           }
+        },
+        "leasingInfo": {
+          "type": "object",
+          "description": "Property. Leasing contract information for the vehicle.",
+          "properties": {
+            "leasingType": {
+              "type": "string",
+              "description": "Property. Type of leasing contract"
+            },
+            "leasingStartDate": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Property. Model:'https://schema.org/DateTime'. Start date of the leasing contract"
+            },
+            "leasingEndDate": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Property. Model:'https://schema.org/DateTime'. End date of the leasing contract"
+            },
+            "monthlyLeaseCost": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Fixed monthly lease payment amount in the contract currency"
+            },
+            "allowedAnnualDistance": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Maximum allowed annual distance according to lease contract"
+            },
+            "allowedDistanceUnit": {
+              "type": "string",
+              "enum": [
+                "kilometer",
+                "mile"
+              ],
+              "description": "Property. Unit for distance measurements in the lease contract"
+            },
+            "excessDistanceCost": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Cost per unit distance for exceeding the allowed annual distance"
+            },
+            "leasingProvider": {
+              "type": "string",
+              "description": "Property. Name or identifier of the leasing company"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
PR to accept a `leasingInfo` value in the `Vehicle`.

Adopters will be a project funded by OS2.eu, an open source community for danish municipalities. The project aims to allow municipalities to collect GPS data from their fleet.

As of now, there is no obvious place to store information relevant to leasing information. This information is essential for municipalities in order to track their leasing contracts and the service. 

Contribution agreement has been signed with my user @andreasDroid
We wish to appear in the `CONTRIBUTORS.yaml` as organisation and not as a specific individual.